### PR TITLE
upper and number removed from random string in data factory name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,9 @@ module "labels" {
 resource "random_string" "random" {
   length  = 5
   special = false
-  numeric = true
+  lower   = true
+  upper   = false
+  numeric = false
 
   keepers = {
     domain_name_label = var.name


### PR DESCRIPTION
## what
* There was having errors and issues while data factory name is attaching with domain name.

## why
* Provide the justifications for the changes (e.g. business case).
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
