### PR TITLE
hurodata[47] added var for managed vnet in data factory resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,12 +27,13 @@ resource "random_string" "random" {
 }
 
 resource "azurerm_data_factory" "factory" {
-  count                  = var.enabled ? 1 : 0
-  name                   = format("%s-data-factory", module.labels.id)
-  location               = var.location
-  resource_group_name    = var.resource_group_name
-  public_network_enabled = var.public_network_enabled
-  tags                   = module.labels.tags
+  count                           = var.enabled ? 1 : 0
+  name                            = format("%s-data-factory", module.labels.id)
+  location                        = var.location
+  resource_group_name             = var.resource_group_name
+  public_network_enabled          = var.public_network_enabled
+  managed_virtual_network_enabled = var.managed_virtual_network_enabled
+  tags                            = module.labels.tags
 
   lifecycle {
     ignore_changes = [

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "public_network_enabled" {
   description = "Is the Data Factory visible to the public network? Defaults to true."
 }
 
+variable "managed_virtual_network_enabled" {
+  type        = bool
+  default     = null
+  description = "Is default virtual machine enabled for data factory or not."
+}
+
 # Identity
 variable "identity_type" {
   description = "Specifies the type of Managed Service Identity that should be configured on this Storage Account. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both)."


### PR DESCRIPTION
## what
* Added the variable to enabled managed virtual network for data factory.

## why
* It was needed in some projects.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
